### PR TITLE
add methods to convert entity data to jhipster format

### DIFF
--- a/lib/data/association_data.js
+++ b/lib/data/association_data.js
@@ -1,0 +1,33 @@
+'use strict';
+
+const merge = require('../helpers/helper').merge;
+
+/**
+ * The class holding association data.
+ */
+class AssociationData {
+  constructor(values) {
+    var merged = merge(defaults(), values);
+    this.from = merged.from;
+    this.to = merged.to;
+    this.type = merged.type;
+    this.injectedFieldInFrom = merged.injectedFieldInFrom;
+    this.injectedFieldInTo = merged.injectedFieldInTo;
+    this.commentInFrom = merged.commentInFrom;
+    this.commentInTo = merged.commentInTo;
+  }
+}
+
+module.exports = AssociationData;
+
+function defaults() {
+  return {
+    from: null,
+    to: null,
+    type: '',
+    injectedFieldInFrom: null,
+    injectedFieldInTo: null,
+    commentInFrom: '',
+    commentInTo: ''
+  };
+}

--- a/lib/data/class_data.js
+++ b/lib/data/class_data.js
@@ -1,0 +1,49 @@
+'use strict';
+
+const merge = require('../helpers/helper').merge;
+
+/**
+ * The class holding class data.
+ */
+class ClassData {
+  constructor(values) {
+    var merged = merge(defaults(), values);
+    this.name = merged.name;
+    this.tableName = merged.tableName || this.name;
+    this.fields = merged.fields;
+    this.comment = merged.comment;
+    this.dto = merged.dto;
+    this.pagination = merged.pagination;
+    this.service = merged.service;
+    if (merged.microserviceName) {
+      this.microserviceName = merged.microserviceName;
+    }
+    if (merged.searchEngine) {
+      this.searchEngine = merged.searchEngine;
+    }
+  }
+
+  /**
+   * Adds a field to the class.
+   * @param {Object} field the field to add.
+   * @return {ClassData} this modified class.
+   */
+  addField(field) {
+    this.fields.push(field);
+    return this;
+  }
+}
+
+module.exports = ClassData;
+
+function defaults() {
+  return {
+    name: '',
+    tableName: '',
+    fields: [],
+    comment: '',
+    dto: 'no',
+    pagination: 'no',
+    service: 'no'
+  };
+}

--- a/lib/data/enum_data.js
+++ b/lib/data/enum_data.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const merge = require('../helpers/helper').merge;
+
+/**
+ * The class holding enumeration data.
+ */
+class EnumData {
+  constructor(values) {
+    var merged = merge(defaults(), values);
+    this.name = merged.name;
+    this.values = merged.values;
+  }
+}
+
+module.exports = EnumData;
+
+function defaults() {
+  return {
+    name: '',
+    values: []
+  };
+}

--- a/lib/data/field_data.js
+++ b/lib/data/field_data.js
@@ -1,0 +1,37 @@
+'use strict';
+
+const merge = require('../helpers/helper').merge;
+
+/**
+ * The class holding field data.
+ */
+class FieldData {
+  constructor(values) {
+    var merged = merge(defaults(), values);
+    this.name = merged.name;
+    this.type = merged.type;
+    this.comment = merged.comment;
+    this.validations = merged.validations;
+  }
+
+  /**
+   * Adds a validation to the field.
+   * @param {Object} validation the validation to add.
+   * @return {FieldData} this modified class.
+   */
+  addValidation(validation) {
+    this.validations.push(validation);
+    return this;
+  }
+}
+
+module.exports = FieldData;
+
+function defaults() {
+  return {
+    name: '',
+    type: '',
+    comment: '',
+    validations: []
+  };
+}

--- a/lib/data/parsed_data.js
+++ b/lib/data/parsed_data.js
@@ -1,0 +1,137 @@
+'use strict';
+
+const ClassData = require('./class_data'),
+    FieldData = require('./field_data'),
+    TypeData = require('./type_data'),
+    EnumData = require('./enum_data'),
+    AssociationData = require('./association_data'),
+    ValidationData = require('./validation_data');
+
+/**
+ * The parsed data class holds the various information taken from the UML file.
+ */
+class ParsedData {
+  constructor() {
+    this.classes = {};
+    this.fields = {};
+    this.associations = {};
+    this.types = {};
+    this.enums = {};
+    this.validations = {};
+    this.userClassId = null;
+  }
+
+  /**
+   * Adds a new class.
+   * @param id its id.
+   * @param data the class data.
+   */
+  addClass(id, data) {
+    this.classes[id] = new ClassData(data);
+  }
+
+  /**
+   * Adds a new field.
+   * @param classId the class' id.
+   * @param fieldId its id.
+   * @param data the field data.
+   */
+  addField(classId, fieldId, data) {
+    this.fields[fieldId] = new FieldData(data);
+    this.classes[classId].addField(fieldId);
+  }
+
+  /**
+   * Adds a validation to a field.
+   * @param fieldId the field's id.
+   * @param validationId the validation's id.
+   * @param data the validation data.
+   */
+  addValidationToField(fieldId, validationId, data) {
+    this.validations[validationId] = new ValidationData(data);
+    this.fields[fieldId].addValidation(validationId);
+  }
+
+  /**
+   * Gets a validation.
+   * @param validationId he validation's id.
+   * @returns {Object} the validation data.
+   */
+  getValidation(validationId) {
+    return this.validations[validationId];
+  }
+
+  /**
+   * Adds a new association.
+   * @param id its id.
+   * @param data the association data.
+   */
+  addAssociation(id, data) {
+    this.associations[id] = new AssociationData(data);
+  }
+
+  /**
+   * Adds a new type.
+   * @param id its id.
+   * @param data the type data.
+   */
+  addType(id, data) {
+    this.types[id] = new TypeData(data);
+  }
+
+  /**
+   * Adds a new enum.
+   * @param id its id.
+   * @param data the enum data.
+   */
+  addEnum(id, data) {
+    this.enums[id] = new EnumData(data);
+  }
+
+  /**
+   * Gets a type by its id.
+   * @param id the id.
+   * @returns {TypeData} the type.
+   */
+  getType(id) {
+    return this.types[id];
+  }
+
+  /**
+   * Gets a class by its id.
+   * @param id the id.
+   * @returns {ClassData} the class.
+   */
+  getClass(id) {
+    return this.classes[id];
+  }
+
+  /**
+   * Gets a field by its id.
+   * @param id the id.
+   * @returns {FieldData} the field.
+   */
+  getField(id) {
+    return this.fields[id];
+  }
+
+  /**
+   * Gets an association by its id.
+   * @param id the id.
+   * @return {AssociationData} the association.
+   */
+  getAssociation(id) {
+    return this.associations[id];
+  }
+
+  /**
+   * Gets an enum by its id.
+   * @param id the id.
+   * @returns {EnumData} the enumeration.
+   */
+  getEnum(id) {
+    return this.enums[id];
+  }
+}
+
+module.exports = ParsedData;

--- a/lib/data/type_data.js
+++ b/lib/data/type_data.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const merge = require('../helpers/helper').merge;
+
+/**
+ * The class holding type data.
+ */
+class TypeData {
+  constructor(values) {
+    var merged = merge(defaults(), values);
+    this.name = merged.name;
+  }
+}
+
+module.exports = TypeData;
+
+function defaults() {
+  return {
+    name: ''
+  };
+}

--- a/lib/data/validation_data.js
+++ b/lib/data/validation_data.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const merge = require('../helpers/helper').merge;
+
+/**
+ * The class holding validation data.
+ */
+class ValidationData {
+  constructor(values) {
+    var merged = merge(defaults(), values);
+    this.name = merged.name;
+    this.value = merged.value;
+  }
+}
+
+module.exports = ValidationData;
+
+function defaults() {
+  return {
+    name: '',
+    value: null
+  };
+}

--- a/lib/helpers/association_helper.js
+++ b/lib/helpers/association_helper.js
@@ -1,0 +1,84 @@
+'use strict';
+
+const chalk = require('chalk'),
+    AssociationData = require('../data/association_data'),
+    cardinalities = require('../types/cardinalities'),
+    buildException = require('../exceptions/exception_factory').buildException,
+    exceptions = require('../exceptions/exception_factory').exceptions;
+
+
+module.exports = {
+  checkValidityOfAssociation: checkValidityOfAssociation
+};
+
+/**
+ * Checks the validity of the association.
+ * @param {AssociationData} association the association to check.
+ * @param {String} sourceName the source's name.
+ * @param {String} destinationName the destination's name.
+ * @throws NullPointerException if the association is nil.
+ * @throws AssociationException if the association is invalid.
+ */
+function checkValidityOfAssociation (association, sourceName, destinationName) {
+  if (!association || !association.type) {
+    throw new buildException(
+        exceptions.NullPointer, 'The association must not be nil.');
+  }
+  switch (association.type) {
+    case cardinalities.ONE_TO_ONE:
+      checkOneToOne(association, sourceName, destinationName);
+      break;
+    case cardinalities.ONE_TO_MANY:
+      checkOneToMany(association, sourceName, destinationName);
+      break;
+    case cardinalities.MANY_TO_ONE:
+      checkManyToOne(association, sourceName, destinationName);
+      break;
+    case cardinalities.MANY_TO_MANY:
+      checkManyToMany(association, sourceName, destinationName);
+      break;
+    default:
+      throw new buildException(
+          exceptions.WrongAssociation,
+          `The association type ${association.type} isn't supported.`);
+  }
+}
+
+function checkOneToOne(association, sourceName, destinationName) {
+  if (!association.injectedFieldInFrom) {
+    throw new buildException(
+        exceptions.MalformedAssociation,
+        `In the One-to-One relationship from ${sourceName} to ${destinationName}, `
+        + 'the source entity must possess the destination in a One-to-One '
+        + ' relationship, or you must invert the direction of the relationship.');
+  }
+}
+
+function checkOneToMany(association, sourceName, destinationName) {
+  if (!association.injectedFieldInFrom || !association.injectedFieldInTo) {
+    console.warn(
+        chalk.yellow(
+            `In the One-to-Many relationship from ${sourceName} to  ${destinationName}, `
+            + 'only bidirectionality is supported for a One-to-Many association. '
+            + 'The other side will be automatically added.'));
+  }
+}
+
+function checkManyToOne(association, sourceName, destinationName) {
+  if (association.injectedFieldInFrom && association.injectedFieldInTo) {
+    throw new buildException(
+        exceptions.MalformedAssociation,
+        `In the Many-to-One relationship from ${sourceName} to ${destinationName}, `
+        + 'only unidirectionality is supported for a Many-to-One relationship, '
+        + 'you should create a bidirectional One-to-Many relationship instead.');
+  }
+}
+
+function checkManyToMany(association, sourceName, destinationName) {
+  if (!association.injectedFieldInFrom || !association.injectedFieldInTo) {
+    throw new buildException(
+        exceptions.MalformedAssociation,
+        `In the Many-to-Many relationship from ${sourceName} to ${destinationName}, `
+        + 'only bidirectionality is supported for a Many-to-Many relationship.');
+  }
+}

--- a/lib/helpers/entity_helper.js
+++ b/lib/helpers/entity_helper.js
@@ -1,0 +1,97 @@
+'use strict';
+
+module.exports = {
+  isAValidDTO: isAValidDTO,
+  isAValidPagination: isAValidPagination,
+  isAValidService: isAValidService,
+  isAnId: isAnId,
+  areJHipsterEntitiesEqual: areJHipsterEntitiesEqual
+};
+
+const DTO_OPTIONS = {mapstruct: null};
+const PAGINATION_OPTIONS = {
+  pager: null,
+  pagination: null,
+  'infinite-scroll': null
+};
+const SERVICE_OPTIONS = {
+  serviceClass: null,
+  serviceImpl: null
+};
+const SEARCH_ENGINE_OPTIONS = {elasticsearch: null};
+
+/**
+ * Checks whether the passed dto option is valid.
+ * @param {string} the dto option.
+ * @return {boolean}
+ */
+function isAValidDTO(dto) {
+  return DTO_OPTIONS.hasOwnProperty(dto);
+}
+
+/**
+ * Checks whether the passed pagination option is valid.
+ * @param {string} the pagination option.
+ * @return {boolean}
+ */
+function isAValidPagination(pagination) {
+  return PAGINATION_OPTIONS.hasOwnProperty(pagination);
+}
+
+/**
+ * Checks whether the passed service option is valid.
+ * @param {string} the service option.
+ * @return {boolean}
+ */
+function isAValidService(service) {
+  return SERVICE_OPTIONS.hasOwnProperty(service);
+}
+
+/**
+ * Checks whether the passed name is an id.
+ * @param {string} name the field's name.
+ * @return {boolean}
+ */
+function isAnId(name) {
+  return /^id$/.test(name.toLowerCase());
+};
+
+/**
+ * Checks whether two entities are equal
+ * @param {object} first entity object
+ * @param {object} second entity object
+ * @return {boolean}
+ */
+function areJHipsterEntitiesEqual(firstEntity, secondEntity) {
+  if (firstEntity.fields.length !== secondEntity.fields.length
+      || firstEntity.relationships.length !== secondEntity.relationships.length) {
+    return false;
+  }
+  return areFieldsEqual(firstEntity.fields, secondEntity.fields)
+    && areRelationshipsEqual(firstEntity.relationships, secondEntity.relationships);
+}
+
+/* private methods */
+function areFieldsEqual(firstFields, secondFields) {
+  return firstFields.every(function(field, index) {
+    if (Object.keys(field).length !== Object.keys(secondFields[index]).length) {
+      return false;
+    }
+    var secondEntityField = secondFields[index];
+    return Object.keys(field).every(function(key) {
+      return field[key] === secondEntityField[key];
+    });
+  });
+}
+
+function areRelationshipsEqual(firstRelationships, secondRelationships) {
+  return firstRelationships.every(function(relationship, index) {
+    if (Object.keys(relationship).length !== Object.keys(secondRelationships[index]).length) {
+      return false;
+    }
+    var secondEntityRelationship = secondRelationships[index];
+    return Object.keys(relationship).every(function(key) {
+      return relationship[key] === secondEntityRelationship[key];
+    });
+  });
+}

--- a/lib/helpers/helper.js
+++ b/lib/helpers/helper.js
@@ -1,0 +1,50 @@
+'use strict';
+
+module.exports = {
+  merge: merge,
+  formatComment: formatComment
+};
+
+
+/**
+ * Merge two objects.
+ * The order is important here: o1.merge(o2) means that the keys values of o2
+ * will replace those identical to o1.
+ * The keys that don't belong to the other object will be added.
+ * @param object2 the object to be merged with.
+ * @returns {Object} the object result of the merge
+ */
+function merge(object1, object2) {
+  if (!object1 || Object.keys(object1).length === 0) {
+    return object2;
+  }
+  if (!object2 || Object.keys(object2).length === 0) {
+    return object1;
+  }
+  var merged = {};
+  for (let key in object1) {
+    merged[key] = object1[key];
+  }
+  for (let key in object2) {
+    merged[key] = object2[key];
+  }
+  return merged;
+}
+
+/**
+ * formatts a comment
+ * @param {String} comment string.
+ * @returns {String} formatted comment string
+ */
+function formatComment(comment) {
+  if (!comment) {
+    return;
+  }
+  var parts = comment.trim().split('\n');
+  if (parts.length === 1 && parts[0].indexOf('*') !== 0) {
+    return parts[0];
+  }
+  return parts.reduce(function(previousValue, currentValue) {
+    return previousValue.concat(currentValue.trim().replace(/[*]*\s*/, ''));
+  }, '');
+}

--- a/lib/reader/entity_creator.js
+++ b/lib/reader/entity_creator.js
@@ -1,0 +1,416 @@
+'use strict';
+
+const chalk = require('chalk'),
+    fs = require('fs'),
+    _ = require('lodash'),
+    areJHipsterEntitiesEqual = require('../helpers/entity_helper').areJHipsterEntitiesEqual,
+    types_helper = require('../types/types_helper'),
+    association_helper = require('../helpers/association_helper'),
+    cardinalities = require('../types/cardinalities'),
+    formatComment = require('../helpers/helper').formatComment,
+    buildException = require('../exceptions/exception_factory').buildException,
+    exceptions = require('../exceptions/exception_factory').exceptions;
+
+/**
+ * Keys of args:
+ *   - parsedData,
+ *   - databaseTypes
+ */
+var EntitiesCreator = module.exports = function (args) {
+  if (!args.parsedData || !args.databaseTypes) {
+    throw new buildException(
+        exceptions.NullPointer,
+        'The parsed data and database types are mandatory.');
+  }
+
+  this.USER = 'User';
+  this.entitiesToSuppress = [];
+
+  this.databaseTypes = args.databaseTypes;
+  this.parsedData = args.parsedData;
+
+  this.checkNoSQLModeling();
+
+  this.entities = {};
+  // cache for the the entities read on the disk
+  this.onDiskEntities = {};
+};
+
+EntitiesCreator.prototype.getEntities = function () {
+  return this.entities;
+};
+
+EntitiesCreator.prototype.createEntities = function () {
+  this.initializeEntities();
+
+  Object.keys(this.parsedData.classes).forEach(function (classId) {
+
+    /*
+     * If the user adds a 'User' entity we consider it as the already
+     * created JHipster User entity and none of its fields and ownerside
+     * relationships will be considered.
+     */
+    if (this.parsedData.getClass(classId).name.toLowerCase() === this.USER.toLowerCase()) {
+      console.warn(
+          chalk.yellow(
+              "Warning:  An Entity called 'User' was defined: 'User' is an" +
+              ' entity created by default by JHipster. All relationships toward' +
+              ' it will be kept but all attributes and relationships from it' +
+              ' will be disregarded.'));
+      this.entitiesToSuppress.push(classId);
+    }
+    this.setFieldsOfEntity(classId);
+    this.setRelationshipOfEntity(classId);
+  }, this);
+
+  this.entitiesToSuppress.forEach(function (entity) {
+    delete this.entities[entity];
+  }, this);
+
+};
+
+/**
+ * Initialize all Entities with default values
+ */
+EntitiesCreator.prototype.initializeEntities = function () {
+  this.onDiskEntities = this.readJSON(Object.keys(this.parsedData.classes));
+
+  Object.keys(this.parsedData.classes).forEach(function (classId, index) {
+    var initializedEntity = {
+      relationships: [],
+      fields: [],
+      changelogDate: this.getChangelogDate(classId, index),
+      dto: this.parsedData.getClass(classId).dto,
+      pagination: this.parsedData.getClass(classId).pagination,
+      service: this.parsedData.getClass(classId).service,
+      microserviceName: this.parsedData.getClass(classId).microserviceName,
+      searchEngine: this.parsedData.getClass(classId).searchEngine,
+      javadoc: formatComment(this.parsedData.getClass(classId).comment),
+      entityTableName: _.snakeCase(this.parsedData.getClass(classId).tableName)
+    };
+
+    initializedEntity = this.setDTO(
+        initializedEntity,
+        this.parsedData.getClass(classId).name);
+    initializedEntity = this.setPagination(
+        initializedEntity,
+        this.parsedData.getClass(classId).name);
+    initializedEntity = this.setService(
+        initializedEntity,
+        this.parsedData.getClass(classId).name);
+    initializedEntity = this.setMicroserviceNames(
+        initializedEntity,
+        this.parsedData.getClass(classId).name);
+    initializedEntity = this.setSearchEngine(
+        initializedEntity,
+        this.parsedData.getClass(classId).name
+    );
+
+    this.entities[classId] = initializedEntity;
+  }, this);
+};
+
+/**
+ * If the entity already have a json file we get the changelogDate in it
+ * else we create the changelogDate with liquibase date format
+ * @param{String} classId  the id of the class to set the changelogDate property
+ * @param{Integer} increment the optional increment in the timestamp?
+ * @return the date on liquibase format
+ */
+EntitiesCreator.prototype.getChangelogDate = function (classId, increment) {
+  if (this.onDiskEntities[classId]) {
+    return this.onDiskEntities[classId].changelogDate;
+  }
+  return dateFormatForLiquibase(increment);
+};
+
+/**
+ * fill the fields of the current entity
+ * param{String} classId the id of the current entity
+ */
+EntitiesCreator.prototype.setFieldsOfEntity = function (classId) {
+  this.parsedData.classes[classId].fields.forEach(function (fieldId) {
+    var fieldData = {
+      fieldId: this.entities[classId].fields.length + 1,
+      fieldName: _.camelCase(this.parsedData.getField(fieldId).name),
+      javadoc: formatComment(this.parsedData.getField(fieldId).comment)
+    };
+
+    if (this.parsedData.types[this.parsedData.getField(fieldId).type]) {
+      fieldData.fieldType = this.parsedData.getType(this.parsedData.getField(fieldId).type).name;
+    } else if (this.parsedData.getEnum(this.parsedData.getField(fieldId).type)) {
+      fieldData.fieldType = this.parsedData.getEnum(this.parsedData.getField(fieldId).type).name;
+      fieldData.fieldValues = this.parsedData.getEnum(this.parsedData.getField(fieldId).type).values.join(',');
+    }
+
+    if (fieldData.fieldType === 'ImageBlob') {
+      fieldData.fieldType = 'byte[]';
+      fieldData.fieldTypeBlobContent = 'image';
+    } else if (fieldData.fieldType === 'Blob' || fieldData.fieldType === 'AnyBlob') {
+      fieldData.fieldType = 'byte[]';
+      fieldData.fieldTypeBlobContent = 'any';
+    }
+
+    this.setValidationsOfField(fieldData, fieldId);
+    this.entities[classId].fields.push(fieldData);
+  }, this);
+};
+
+/**
+ * Gets a fields and adds the related validations.
+ * @param {Object} field the field.
+ * @param {String} fieldId the field's id.
+ */
+EntitiesCreator.prototype.setValidationsOfField = function (field, fieldId) {
+  if (this.parsedData.getField(fieldId).validations.length === 0) {
+    return;
+  }
+  field.fieldValidateRules = [];
+
+  this.parsedData.getField(fieldId).validations.forEach(function (validationId) {
+    var validation = this.parsedData.getValidation(validationId);
+    field.fieldValidateRules.push(validation.name);
+    if (validation.name !== 'required') {
+      field['fieldValidateRules' + _.capitalize(validation.name)] =
+          validation.value;
+    }
+  }, this);
+
+};
+
+function getRelatedAssociations(classId, associationIds, associations) {
+  var relationships = {
+    from: [],
+    to: []
+  };
+  associationIds.forEach(function (associationId) {
+    var association = associations[associationId];
+    if (association.from === classId) {
+      relationships.from.push(associationId);
+    }
+    if (association.to === classId && association.injectedFieldInTo) {
+      relationships.to.push(associationId);
+    }
+  }, this);
+  return relationships;
+}
+
+/**
+ * Parses the string "<relationshipName>(<otherEntityField>)"
+ * @param{String} field
+ * @return{Object} where 'relationshipName' is the relationship name and
+ *                'otherEntityField' is the other entity field name
+ */
+function extractField(field) {
+  var splitField = {
+    otherEntityField: 'id', // id by default
+    relationshipName: ''
+  };
+  if (field) {
+    var chunks = field.replace('(', '/').replace(')', '').split('/');
+    splitField.relationshipName = chunks[0];
+    if (chunks.length > 1) {
+      splitField.otherEntityField = chunks[1];
+    }
+  }
+  return splitField;
+}
+
+EntitiesCreator.prototype.setRelationshipOfEntity = function (classId) {
+  var associations = getRelatedAssociations(
+      classId,
+      Object.keys(this.parsedData.associations),
+      this.parsedData.associations);
+  associations.from.forEach(function (associationId) {
+    var otherSplitField;
+    var splitField;
+    var association = this.parsedData.getAssociation(associationId);
+    association_helper.checkValidityOfAssociation(
+        association,
+        this.parsedData.getClass(association.from).name,
+        this.parsedData.getClass(association.to).name);
+    var relationship = {
+      relationshipId: this.entities[classId].relationships.length + 1,
+      relationshipType: association.type
+    };
+    if (association.type === cardinalities.ONE_TO_ONE) {
+      splitField = extractField(association.injectedFieldInFrom);
+      relationship.relationshipName = _.camelCase(splitField.relationshipName);
+      relationship.otherEntityName = _.lowerFirst(_.camelCase(this.parsedData.getClass(association.to).name));
+      relationship.otherEntityField = _.lowerFirst(splitField.otherEntityField);
+      relationship.ownerSide = true;
+      relationship.otherEntityRelationshipName = _.lowerFirst(association.injectedFieldInTo || this.parsedData.getClass(association.from).name);
+    } else if (association.type === cardinalities.ONE_TO_MANY) {
+      splitField = extractField(association.injectedFieldInFrom);
+      otherSplitField = extractField(association.injectedFieldInTo);
+      relationship.relationshipName = _.lowerFirst(_.camelCase(splitField.relationshipName || this.parsedData.getClass(association.to).name));
+      relationship.otherEntityName = _.lowerFirst(_.camelCase(this.parsedData.getClass(association.to).name));
+      relationship.otherEntityRelationshipName = _.lowerFirst(otherSplitField.relationshipName);
+      if (!association.injectedFieldInTo) {
+        relationship.otherEntityRelationshipName = _.lowerFirst(this.parsedData.getClass(association.from).name);
+        otherSplitField = extractField(association.injectedFieldInTo);
+        var otherSideRelationship = {
+          relationshipId: this.entities[association.to].relationships.length + 1,
+          relationshipName: _.camelCase(_.lowerFirst(this.parsedData.getClass(association.from).name)),
+          otherEntityName: _.lowerFirst(_.camelCase(this.parsedData.getClass(association.from).name)),
+          relationshipType: cardinalities.MANY_TO_ONE,
+          otherEntityField: _.lowerFirst(otherSplitField.otherEntityField)
+        };
+        association.type = cardinalities.MANY_TO_ONE;
+        this.entities[association.to].relationships.push(otherSideRelationship);
+      }
+    } else if (association.type === cardinalities.MANY_TO_ONE && association.injectedFieldInFrom) {
+      splitField = extractField(association.injectedFieldInFrom);
+      relationship.relationshipName = _.camelCase(splitField.relationshipName);
+      relationship.otherEntityName = _.lowerFirst(_.camelCase(this.parsedData.getClass(association.to).name));
+      relationship.otherEntityField = _.lowerFirst(splitField.otherEntityField);
+    } else if (association.type === cardinalities.MANY_TO_MANY) {
+      splitField = extractField(association.injectedFieldInFrom);
+      relationship.relationshipName = _.camelCase(splitField.relationshipName);
+      relationship.otherEntityName = _.lowerFirst(_.camelCase(this.parsedData.getClass(association.to).name));
+      relationship.otherEntityField = _.lowerFirst(splitField.otherEntityField);
+      relationship.ownerSide = true;
+    }
+    this.entities[classId].relationships.push(relationship);
+  }, this);
+  associations.to.forEach(function (associationId) {
+    var splitField;
+    var otherSplitField;
+    var association = this.parsedData.getAssociation(associationId);
+    var relationship = {
+      relationshipId: this.entities[classId].relationships.length + 1,
+      relationshipType: (association.type === cardinalities.ONE_TO_MANY ? cardinalities.MANY_TO_ONE : association.type)
+    };
+    if (association.type === cardinalities.ONE_TO_ONE) {
+      splitField = extractField(association.injectedFieldInTo);
+      otherSplitField = extractField(association.injectedFieldInFrom);
+      relationship.relationshipName = _.camelCase(splitField.relationshipName);
+      relationship.otherEntityName = _.lowerFirst(_.camelCase(this.parsedData.getClass(association.from).name));
+      relationship.ownerSide = false;
+      relationship.otherEntityRelationshipName = _.lowerFirst(otherSplitField.relationshipName);
+    } else if (association.type === cardinalities.ONE_TO_MANY) {
+      association.injectedFieldInTo = association.injectedFieldInTo || _.lowerFirst(association.from);
+      splitField = extractField(association.injectedFieldInTo);
+      relationship.relationshipName = _.lowerFirst(_.camelCase(splitField.relationshipName || this.parsedData.getClass(association.from).name));
+      relationship.otherEntityName = _.lowerFirst(_.camelCase(this.parsedData.getClass(association.from).name));
+      relationship.otherEntityField = _.lowerFirst(splitField.otherEntityField);
+    } else if (association.type === cardinalities.MANY_TO_ONE && association.injectedFieldInTo) {
+      splitField = extractField(association.injectedFieldInTo);
+      relationship.relationshipName = _.camelCase(splitField.relationshipName);
+      relationship.otherEntityName = _.lowerFirst(_.camelCase(this.parsedData.getClass(association.from).name));
+      relationship.otherEntityField = _.lowerFirst(splitField.otherEntityField);
+    } else if (association.type === cardinalities.MANY_TO_MANY) {
+      splitField = extractField(association.injectedFieldInTo);
+      relationship.relationshipName = _.camelCase(splitField.relationshipName);
+      relationship.otherEntityName = _.lowerFirst(_.camelCase(this.parsedData.getClass(association.from).name));
+      relationship.ownerSide = false;
+      relationship.otherEntityRelationshipName = _.lowerFirst(extractField(association.injectedFieldInFrom).relationshipName);
+    }
+    this.entities[classId].relationships.push(relationship);
+  }, this);
+};
+
+/**
+ * For each class in classesToRead, reads the corresponding JSON in .jhipster.
+ * @param{array} classesToRead all the classes we want to read.
+ * @return {object} the read entities.
+ */
+EntitiesCreator.prototype.readJSON = function (classesToRead) {
+  var entitiesRead = {};
+  classesToRead.forEach(function (classToRead) {
+    var file = '.jhipster/' + this.parsedData.getClass(classToRead).name + '.json';
+
+    if (this.onDiskEntities[classToRead]) {
+      entitiesRead[classToRead] = this.onDiskEntities[classToRead];
+    } else if (fs.existsSync(file)) {
+      entitiesRead[classToRead] = JSON.parse(fs.readFileSync(file, 'utf8'));
+    }
+  }, this);
+  return entitiesRead;
+};
+
+/**
+ * @param{Array} classList  the classes we want to create a JSON for
+ * Return an object map of all the entity in classList
+ */
+EntitiesCreator.prototype.getEntitiesMap = function (classList) {
+  var entitiesMap = {};
+  for (var k in entities) {
+    if (this.entities.hasOwnProperty(k) && classList.indexOf(k) !== -1) {
+      entitiesMap[this.parsedData.getClass(k).name] = this.entities[k];
+    }
+  }
+  return entitiesMap;
+};
+
+/**
+ * @param{Array} classList  the classes we want to create a JSON for
+ * Write a JSON file for each entity in classList in the .jhipster folder
+ */
+EntitiesCreator.prototype.writeJSON = function (classList) {
+  if (!fs.existsSync('.jhipster')) {
+    fs.mkdirSync('.jhipster');
+  }
+
+  for (var k in this.entities) {
+    if (this.entities.hasOwnProperty(k) && classList.indexOf(k) !== -1) {
+      var file = '.jhipster/' + this.parsedData.getClass(k).name + '.json';
+      fs.writeFileSync(file, JSON.stringify(this.entities[k], null, 4));
+    }
+  }
+};
+
+/**
+ * Removes all unchanged entities.
+ * @param {Array} entities all the entities to filter.
+ * @returns {Array} the changed entities.
+ */
+EntitiesCreator.prototype.filterOutUnchangedEntities = function (entities) {
+  var onDiskEntities = this.readJSON(entities);
+  return entities.filter(function (id) {
+    var currEntity = onDiskEntities[id];
+    var newEntity = this.entities[id];
+    if (!currEntity) {
+      return true;
+    }
+    return !areJHipsterEntitiesEqual(currEntity, newEntity);
+  }, this);
+};
+
+/*
+ * Throws an error if the user declared relationships when using a NoSQL database
+ */
+EntitiesCreator.prototype.checkNoSQLModeling = function () {
+  if (types_helper.isNoSQL(this.databaseTypes)
+      && Object.keys(this.parsedData.associations).length !== 0) {
+    throw new buildException(
+        exceptions.NoSQLModeling, "NoSQL entities don't have relationships.");
+  }
+};
+
+function dateFormatForLiquibase(increment) {
+  var now = new Date();
+  var now_utc = new Date(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate(), now.getUTCHours(), now.getUTCMinutes(), now.getUTCSeconds());
+  var year = '' + now_utc.getFullYear();
+  var month = '' + (now_utc.getMonth() + 1);
+  if (month.length === 1) {
+    month = '0' + month;
+  }
+  var day = '' + now_utc.getDate();
+  if (day.length === 1) {
+    day = '0' + day;
+  }
+  var hour = '' + now_utc.getHours();
+  if (hour.length === 1) {
+    hour = '0' + hour;
+  }
+  var minute = '' + now_utc.getMinutes();
+  if (minute.length === 1) {
+    minute = '0' + minute;
+  }
+  var second = '' + (now_utc.getSeconds() + increment) % 60;
+  if (second.length === 1) {
+    second = '0' + second;
+  }
+  return year + '' + month + '' + day + '' + hour + '' + minute + '' + second;
+}

--- a/lib/reader/entity_parser.js
+++ b/lib/reader/entity_parser.js
@@ -1,0 +1,241 @@
+"use strict";
+
+const _ = require('lodash'),
+    chalk = require('chalk'),
+    isAValidDTO = require('../helpers/entity_helper').isAValidDTO,
+    isAValidPagination = require('../helpers/entity_helper').isAValidPagination,
+    isAValidService = require('../helpers/entity_helper').isAValidService,
+    isAnId = require('../helpers/entity_helper').isAnId,
+    buildException = require('../exceptions/exception_factory').buildException,
+    exceptions = require('../exceptions/exception_factory').exceptions,
+    ParsedData = require('../data/parsed_data');
+
+/**
+ * The parser for our DSL files.
+ */
+var DSLParser = module.exports = function (content, databaseTypes) {
+  this.result = content;
+  this.databaseTypes = databaseTypes
+  this.parsedData = new ParsedData();
+};
+
+DSLParser.prototype.parse = function () {
+  this.fillEnums();
+  this.fillClassesAndFields();
+  this.fillAssociations();
+  return this.parsedData;
+};
+
+/*
+ * Fills the enums
+ */
+DSLParser.prototype.fillEnums = function () {
+  this.result.enums.forEach(function (enumObject) {
+    this.addEnum(enumObject);
+  }, this);
+};
+
+/**
+ * Fills the associations with the extracted associations from the document.
+ */
+DSLParser.prototype.fillAssociations = function () {
+  this.result.relationships.forEach(function (relationship) {
+
+    var associationId = relationship.from.name
+        + '_'
+        + relationship.from.injectedfield
+        + '_to_'
+        + relationship.to.name
+        + '_'
+        + relationship.to.injectedfield;
+    this.checkEntityDeclaration(relationship);
+
+    var associationData = {
+      from: _.upperFirst(relationship.from.name),
+      to: _.upperFirst(relationship.to.name),
+      type: relationship.cardinality,
+      injectedFieldInFrom: relationship.from.injectedfield,
+      injectedFieldInTo: relationship.to.injectedfield,
+      commentInFrom: relationship.from.javadoc,
+      commentInTo: relationship.to.javadoc
+    };
+
+    this.parsedData.addAssociation(associationId, associationData);
+  }, this);
+};
+
+/**
+ * Fills the classes and the fields that compose them.
+ * @throws NullPointerException if a class' name, or an attribute, is nil.
+ */
+DSLParser.prototype.fillClassesAndFields = function () {
+  this.result.entities.forEach(function (entity) {
+    this.addClass(entity);
+    entity.body.forEach(function (bodyData) {
+      this.addField(bodyData, entity.name);
+    }, this);
+  }, this);
+  addDTOOptions(this.result.dto, this.parsedData);
+  addPaginationOptions(this.result.pagination, this.parsedData);
+  addServiceOptions(this.result.service, this.parsedData);
+};
+
+function addDTOOptions(dtos, parsedData) {
+  Object.keys(dtos).forEach(function (option) {
+    if (isAValidDTO(option)) {
+      var collection = (dtos[option].list[0] === '*')
+          ? Object.keys(parsedData.classes)
+          : dtos[option].list;
+      if (dtos[option].excluded.length !== 0) {
+        collection = collection.filter(function (className) {
+          return dtos[option].excluded.indexOf(className) === -1;
+        });
+      }
+      collection.forEach(function (className) {
+        parsedData.getClass(className).dto = option;
+      });
+    } else {
+      console.error(
+          chalk.red(
+              "The DTO option '" + option + "' is not supported."));
+    }
+  });
+}
+
+function addPaginationOptions(paginations, parsedData) {
+  Object.keys(paginations).forEach(function (option) {
+    if (isAValidPagination(option)) {
+      var collection = (paginations[option].list[0] === '*')
+          ? Object.keys(parsedData.classes)
+          : paginations[option].list;
+      if (paginations[option].excluded.length !== 0) {
+        collection = collection.filter(function (className) {
+          return paginations[option].excluded.indexOf(className) === -1;
+        });
+      }
+      collection.forEach(function (className) {
+        parsedData.getClass(className).pagination = option;
+      });
+    } else {
+      console.error(
+          chalk.red(
+              "The pagination option '" + option + "' is not supported."));
+    }
+  });
+}
+
+function addServiceOptions(services, parsedData) {
+  Object.keys(services).forEach(function (option) {
+    if (isAValidService(option)) {
+      var collection = (services[option].list[0] === '*')
+          ? Object.keys(parsedData.classes)
+          : services[option].list;
+      if (services[option].excluded.length !== 0) {
+        collection = collection.filter(function (className) {
+          return services[option].excluded.indexOf(className) === -1;
+        });
+      }
+      collection.forEach(function (className) {
+        parsedData.getClass(className).service = option;
+      });
+    } else {
+      console.error(
+          chalk.red(
+              "The service option '" + option + "' is not supported."));
+    }
+  });
+}
+
+DSLParser.prototype.addEnum = function (element) {
+  this.parsedData.addEnum(
+      element.name, {
+        name: element.name,
+        values: element.values
+      });
+};
+
+DSLParser.prototype.addClass = function (entity) {
+  var classId = entity.name;
+  if (entity.name === 'User') {
+    this.parsedData.userClassId = classId;
+  }
+  this.parsedData.addClass(classId, {
+    name: entity.name,
+    comment: entity.javadoc
+  });
+};
+
+DSLParser.prototype.addField = function (element, classId) {
+  if (isAnId(element.name)) {
+    return;
+  }
+
+  var fieldId = this.parsedData.getClass(classId).name + '_' + element.name;
+  this.parsedData.addField(
+      classId,
+      fieldId,
+      {
+        name: _.lowerFirst(element.name),
+        type: element.type,
+        comment: element.javadoc
+      });
+
+  if (this.databaseTypes.contains(element.type)) {
+    this.parsedData.addType(element.type, {name: element.type});
+    this.addConstraint(element.validations, fieldId, element.type);
+  } else if (this.parsedData.getEnum(element.type) !== -1) {
+    this.addConstraint(element.validations, fieldId, 'Enum');
+  } else {
+    throw new buildException(
+        exceptions.WrongType,
+        `The type '${element.type}' isn't supported by JHipster or declared as an Enum.`);
+  }
+};
+
+DSLParser.prototype.addConstraint = function (constraintList, fieldId, type) {
+  constraintList.forEach(function (element) {
+    var validationName = element.key;
+
+    if (!this.databaseTypes.isValidationSupportedForType(
+            type,
+            validationName)) {
+      throw new buildException(
+          exceptions.WrongValidation,
+          `The validation '${validationName}' isn't supported for the type '${type}'.`);
+    }
+    this.parsedData.addValidationToField(
+        fieldId,
+        fieldId + "_" + element.key,
+        {name: element.key, value: element.value});
+  }, this);
+};
+
+/*
+ * Checks if all the entities stated in the relationship are
+ * declared, and create a class User if the entity User is declared implicitly.
+ * @param {Object} relationship the relationship to check.
+ */
+DSLParser.prototype.checkEntityDeclaration = function (association) {
+  if (!this.parsedData.getClass('User')
+      && (association.from.name === 'User' || association.to.name === 'User')) {
+    this.parsedData.userClassId = 'User';
+    this.parsedData.addClass('User', {name: 'User'});
+  }
+
+  var absentEntities = [];
+
+  if (!this.parsedData.getClass(association.from.name)) {
+    absentEntities.push(association.from.name);
+  }
+  if (!this.parsedData.getClass(association.to.name)) {
+    absentEntities.push(association.to.name);
+  }
+  if (absentEntities.length !== 0) {
+    throw new buildException(
+        exceptions.UndeclaredEntity,
+        `In the relationship between ${association.from.name} and `
+        + `${association.to.name}, ${absentEntities.join(' and ')} `
+        + `${(absentEntities.length === 1 ? 'is' : 'are')} not declared.`
+    );
+  }
+};

--- a/lib/reader/jdl_reader.js
+++ b/lib/reader/jdl_reader.js
@@ -2,32 +2,59 @@
 
 const fs = require('fs'),
     jdlParser = require('../dsl/jdl_parser'),
+    DSLParser = require('./entity_parser'),
+    EntitiesCreator = require('./entity_creator'),
+    initDatabaseTypeHolder = require('../types/types_helper').initDatabaseTypeHolder,
     buildException = require('../exceptions/exception_factory').buildException,
     exceptions = require('../exceptions/exception_factory').exceptions;
 
 module.exports = {
-  read: readContent,
-  readFiles: readFiles
+  parse: parse,
+  parseFromFiles: parseFromFiles,
+  convertToEntityJson: convertToEntityJson
 };
 
-function readFiles(files) {
-  if (!files || files.length === 0) {
-    throw new buildException(
-        exceptions.IllegalArgument, 'The file/s must be passed.');
-  }
-  checkAllTheFilesAreJDLFiles(files);
-  return readContent(files.length === 1
-      ? readFileContent(files[0])
-      : aggregateFiles(files));
-}
-
-function readContent(content) {
+/* Parse the given content and return an intermediate object */
+function parse(content) {
   if (!content || content.length === 0) {
     throw new buildException(
         exceptions.IllegalArgument, 'The content must be passed.');
   }
   return jdlParser.parse(content);
 }
+
+/* Parse the given files and return an intermediate object */
+function parseFromFiles(files) {
+  if (!files || files.length === 0) {
+    throw new buildException(
+        exceptions.IllegalArgument, 'The file/s must be passed.');
+  }
+  checkAllTheFilesAreJDLFiles(files);
+  return parse(files.length === 1
+      ? readFileContent(files[0])
+      : aggregateFiles(files));
+}
+
+/* Convert the given intermediate object to JHipster compatible enity JSON array */
+function convertToEntityJson(contentObj, databaseType, force) {
+    var databaseTypes = initDatabaseTypeHolder(databaseType);
+    var parser = new DSLParser(contentObj, databaseTypes);
+    var parsedData = parser.parse();
+    var scheduledClasses = parsedData.classes;
+    if (parsedData.userClassId) {
+        scheduledClasses = filterScheduledClasses(parsedData.userClassId, scheduledClasses);
+    }
+
+    var creator = new EntitiesCreator(parsedData, parser.databaseTypes);
+
+    creator.createEntities();
+    if (!force) {
+        scheduledClasses = creator.filterOutUnchangedEntities(scheduledClasses);
+    }
+    return creator.getEntitiesMap(scheduledClasses);
+}
+
+/* private methods */
 
 function checkAllTheFilesAreJDLFiles(files) {
   for (let i = 0; i < files.length; i++) {
@@ -59,4 +86,10 @@ function readFileContent(file) {
         `The passed file '${file}' must exist and must not be a directory.`);
   }
   return fs.readFileSync(file, 'utf-8').toString();
+}
+
+function filterScheduledClasses(classToFilter, scheduledClasses) {
+    return scheduledClasses.filter(function(element) {
+        return element !== classToFilter;
+    });
 }

--- a/lib/types/abstract_mapped_types.js
+++ b/lib/types/abstract_mapped_types.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const Types = require('./types'),
+    buildException = require('../exceptions/exception_factory').buildException,
+    exceptions = require('../exceptions/exception_factory').exceptions;
+
+var AbstractMappedTypes = module.exports = function () {
+};
+
+// inheritance stuff
+AbstractMappedTypes.prototype = Object.create(Types.prototype);
+AbstractMappedTypes.prototype.constructor = Types;
+
+/**
+ * Method implementation from Type.
+ */
+AbstractMappedTypes.prototype.getTypes = function () {
+  return Object.keys(this.types);
+};
+
+/**
+ * Method implementation from Type.
+ */
+AbstractMappedTypes.prototype.getValidationsForType = function (type) {
+  if (!this.contains(type)) {
+    throw new buildException(
+        exceptions.WrongDatabaseType,
+        `The passed type '${type}' is not supported.`);
+  }
+  return this.types[type];
+};

--- a/lib/types/cardinalities.js
+++ b/lib/types/cardinalities.js
@@ -1,0 +1,13 @@
+'use strict';
+
+const ONE_TO_ONE = 'one-to-one';
+const ONE_TO_MANY= 'one-to-many';
+const MANY_TO_ONE ='many-to-one';
+const MANY_TO_MANY = 'many-to-many';
+
+module.exports = {
+  ONE_TO_ONE: ONE_TO_ONE,
+  ONE_TO_MANY: ONE_TO_MANY,
+  MANY_TO_ONE: MANY_TO_ONE,
+  MANY_TO_MANY: MANY_TO_MANY
+};

--- a/lib/types/cassandra_types.js
+++ b/lib/types/cassandra_types.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const AbstractMappedTypes = require('./abstract_mapped_types');
+
+/**
+ * This class extends the Types interface to provide the Cassandra types
+ * supported by JHipster.
+ */
+var CassandraTypes = module.exports = function () {
+  this.types = {
+    UUID: ['required'],
+    String: ['required', 'minlength', 'maxlength', 'pattern'],
+    Integer: ['required', 'min', 'max'],
+    Long: ['required', 'min', 'max'],
+    BigDecimal: ['required', 'min', 'max'],
+    Date: ['required'],
+    Boolean: ['required'],
+    Float: ['required', 'min', 'max'],
+    Double: ['required', 'min', 'max']
+  };
+};
+
+// inheritance stuff
+CassandraTypes.prototype = Object.create(AbstractMappedTypes.prototype);
+CassandraTypes.prototype.constructor = AbstractMappedTypes;

--- a/lib/types/mongodb_types.js
+++ b/lib/types/mongodb_types.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const AbstractMappedTypes = require('./abstract_mapped_types');
+
+/**
+ * This class extends the Types interface to provide the MongoDB types
+ * supported by JHipster.
+ */
+var MongoDBTypes = module.exports = function () {
+  this.types = {
+    String: ['required', 'minlength', 'maxlength', 'pattern'],
+    Integer: ['required', 'min', 'max'],
+    Long: ['required', 'min', 'max'],
+    BigDecimal: ['required', 'min', 'max'],
+    LocalDate: ['required'],
+    ZonedDateTime: ['required'],
+    Boolean: ['required'],
+    Enum: ['required'],
+    Blob: ['required', 'minbytes', 'maxbytes'],
+    AnyBlob: ['required', 'minbytes', 'maxbytes'],
+    ImageBlob: ['required', 'minbytes', 'maxbytes'],
+    Float: ['required', 'min', 'max'],
+    Double: ['required', 'min', 'max']
+  };
+};
+
+// inheritance stuff
+MongoDBTypes.prototype = Object.create(AbstractMappedTypes.prototype);
+MongoDBTypes.prototype.constructor = AbstractMappedTypes;

--- a/lib/types/sql_types.js
+++ b/lib/types/sql_types.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const AbstractMappedTypes = require('./abstract_mapped_types');
+
+/**
+ * This class extends the Types interface to provide the SQL types supported
+ * by JHipster (for MySQL, PostgreSQL, H2).
+ */
+var SQLTypes = module.exports = function () {
+  this.types = {
+    String: ['required', 'minlength', 'maxlength', 'pattern'],
+    Integer: ['required', 'min', 'max'],
+    Long: ['required', 'min', 'max'],
+    BigDecimal: ['required', 'min', 'max'],
+    LocalDate: ['required'],
+    ZonedDateTime: ['required'],
+    Boolean: ['required'],
+    Enum: ['required'],
+    Blob: ['required', 'minbytes', 'maxbytes'],
+    AnyBlob: ['required', 'minbytes', 'maxbytes'],
+    ImageBlob: ['required', 'minbytes', 'maxbytes'],
+    Float: ['required', 'min', 'max'],
+    Double: ['required', 'min', 'max']
+  };
+};
+
+// inheritance stuff
+SQLTypes.prototype = Object.create(AbstractMappedTypes.prototype);
+SQLTypes.prototype.constructor = AbstractMappedTypes;

--- a/lib/types/types.js
+++ b/lib/types/types.js
@@ -1,0 +1,79 @@
+'use strict';
+
+const buildException = require('../exceptions/exception_factory').buildException,
+    exceptions = require('../exceptions/exception_factory').exceptions;
+
+/**
+ * This interface provides base methods for handling the types.
+ */
+var Types = module.exports = function () {
+};
+
+/**
+ * Must be implemented by subclasses.
+ * Returns the type list.
+ * @return {Array} the type list.
+ * @throws UnimplementedOperationException if the method has not been
+ *                                         implemented by the subclass.
+ */
+Types.prototype.getTypes = function () {
+  throw new buildException(
+      exceptions.UnimplementedOperation,
+      'This method must be implemented by a subclass to be called.');
+};
+
+/**
+ * Must be implemented by subclasses.
+ * Returns the validations for the passed type.
+ * @param type {string} the type.
+ * @return {Array} the validation list.
+ * @throws UnimplementedOperationException if the method has not been
+ *                                         implemented by the subclass.
+ * @throws NoElementFoundException if no type exists for the passed type.
+ */
+Types.prototype.getValidationsForType = function (type) {
+  throw new buildException(
+      exceptions.UnimplementedOperation,
+      'This method must be implemented by a subclass to be called.');
+};
+
+/**
+ * This method converts the internal type map into another array.
+ * Each element is an Object which has a name, and a value.
+ * By default, the name and the value keys have the same value:
+ * [ { name: '1', value: '1' }, { name: '2', value: '2' }, ... ]
+ * @return {Array} the new array.
+ */
+Types.prototype.toValueNameObjectArray = function () {
+  var array = [];
+  for (let key in this.getTypes()) {
+    if (this.getTypes().hasOwnProperty(key)) {
+      let object = {
+        value: this.getTypes()[key],
+        name: this.getTypes()[key]
+      };
+      array.push(object);
+    }
+  }
+  return array;
+};
+
+/**
+ * Checks whether the type is contained in the supported types.
+ * @param {string} type the type to check.
+ * @return {boolean} whether the type is contained in the supported types.
+ */
+Types.prototype.contains = function (type) {
+  return this.getTypes().indexOf(type) !== -1;
+};
+
+/**
+ * Checks whether the type possesses the also passed validation.
+ * @param type {string} the type.
+ * @param validation {string} the validation to check.
+ * @return {boolean} whether the type is validated by the validation.
+ * @throws NoElementFoundException if no type exists for the passed type.
+ */
+Types.prototype.isValidationSupportedForType = function (type, validation) {
+  return this.getValidationsForType(type).indexOf(validation) !== -1;
+};

--- a/lib/types/types_helper.js
+++ b/lib/types/types_helper.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const MongoDBTypes = require('./mongodb_types'),
+  CassandraTypes = require('./cassandra_types'),
+  SQLTypes = require('./sql_types');
+
+/**
+ * Returns true if type is an instance of a NoSQL database type.
+ * @param {type} the type to check.
+ * @return {boolean} whether the passed type is of a NoSQL type.
+ */
+exports.isNoSQL = function (type) {
+  return !SQLTypes.prototype.isPrototypeOf(type);
+};
+
+exports.initDatabaseTypeHolder = function(databaseTypeName) {
+    switch (databaseTypeName) {
+    case 'mongodb':
+        return new MongoDBTypes();
+    case 'cassandra':
+        return new CassandraTypes();
+    default:
+        return new SQLTypes();
+    }
+};

--- a/module/index.js
+++ b/module/index.js
@@ -3,6 +3,7 @@
 const JDLReader = require('../lib/reader/jdl_reader');
 
 module.exports = {
-  parse: JDLReader.read,
-  parseFromFiles: JDLReader.readFiles
+  parse: JDLReader.parse,
+  parseFromFiles: JDLReader.parseFromFiles,
+  convertToEntityJson: JDLReader.convertToEntityJson
 };

--- a/package.json
+++ b/package.json
@@ -30,7 +30,10 @@
       "type": "Apache 2.0"
     }
   ],
-  "dependencies": {},
+  "dependencies": {
+    "chalk": "1.1.3",
+    "lodash": "4.11.2"
+  },
   "devDependencies": {
     "pegjs": "0.9.0",
     "mocha": "2.4.5",

--- a/test/spec/reader/test-reader.js
+++ b/test/spec/reader/test-reader.js
@@ -3,15 +3,15 @@
 var expect = require('chai').expect,
     fs = require('fs'),
     fail = expect.fail,
-    read = require('../../../lib/reader/jdl_reader').read,
-    readFiles = require('../../../lib/reader/jdl_reader').readFiles;
+    parse = require('../../../lib/reader/jdl_reader').parse,
+    parseFromFiles = require('../../../lib/reader/jdl_reader').parseFromFiles;
 
-describe('::readContent', function () {
+describe('::parse', function () {
   describe('when passing invalid parameters', function () {
     describe('such as nil', function () {
       it('throws an error', function () {
         try {
-          read(null);
+          parse(null);
           fail();
         } catch (error) {
           expect(error.name).to.eq('IllegalArgumentException')
@@ -21,7 +21,7 @@ describe('::readContent', function () {
     describe('such as an empty array', function () {
       it('throws an error', function () {
         try {
-          read('');
+          parse('');
           fail();
         } catch (error) {
           expect(error.name).to.eq('IllegalArgumentException')
@@ -33,18 +33,18 @@ describe('::readContent', function () {
     describe('when reading JDL content', function () {
       it('reads it', function () {
         var input = fs.readFileSync('./test/samples/valid_jdl.jdl', 'utf-8').toString();
-        var content = read(input);
+        var content = parse(input);
         expect(content).not.to.be.null;
       });
     });
   });
 });
-describe('::readFiles', function() {
+describe('::parseFromFiles', function() {
   describe('when passing invalid parameters', function () {
     describe('such as nil', function () {
       it('throws an error', function () {
         try {
-          readFiles(null);
+          parseFromFiles(null);
           fail();
         } catch (error) {
           expect(error.name).to.eq('IllegalArgumentException')
@@ -54,7 +54,7 @@ describe('::readFiles', function() {
     describe('such as an empty array', function () {
       it('throws an error', function () {
         try {
-          readFiles([]);
+          parseFromFiles([]);
           fail();
         } catch (error) {
           expect(error.name).to.eq('IllegalArgumentException')
@@ -64,7 +64,7 @@ describe('::readFiles', function() {
     describe("such as files without the '.jh' or '.jdl' file extension", function () {
       it('throws an error', function () {
         try {
-          readFiles(['../../samples/invalid_file.txt']);
+          parseFromFiles(['../../samples/invalid_file.txt']);
           fail();
         } catch (error) {
           expect(error.name).to.eq('WrongFileException')
@@ -74,7 +74,7 @@ describe('::readFiles', function() {
     describe('such as files that do not exist', function () {
       it('throws an error', function () {
         try {
-          readFiles(['nofile.jh']);
+          parseFromFiles(['nofile.jh']);
           fail();
         } catch (error) {
           expect(error.name).to.eq('WrongFileException')
@@ -84,7 +84,7 @@ describe('::readFiles', function() {
     describe('such as folders', function () {
       it('throws an error', function () {
         try {
-          readFiles(['../../samples/folder.jdl']);
+          parseFromFiles(['../../samples/folder.jdl']);
           fail();
         } catch (error) {
           expect(error.name).to.eq('WrongFileException')
@@ -95,13 +95,13 @@ describe('::readFiles', function() {
   describe('when passing valid arguments', function () {
     describe('when reading a single JDL file', function () {
       it('reads it', function () {
-        var content = readFiles(['./test/samples/valid_jdl.jdl']);
+        var content = parseFromFiles(['./test/samples/valid_jdl.jdl']);
         expect(content).not.to.be.null;
       });
     });
     describe('when reading more than one JDL file', function() {
       it('reads them', function () {
-        var content = readFiles(['./test/samples/valid_jdl.jdl', './test/samples/valid_jdl2.jdl']);
+        var content = parseFromFiles(['./test/samples/valid_jdl.jdl', './test/samples/valid_jdl2.jdl']);
         expect(content).not.to.be.null;
       });
     });


### PR DESCRIPTION
@MathieuAA 

I have copied some stuff from JHUML here so that JDL can be used independently for all JDL related tasks, I guess this would result in some code duplication even once all the JDL related stuff are removed from JHUML. But IMO I would prefer code duplication rather than a broken sub generator in the main generator.

I haven't tested this yet. Let me know if you are ok with this approach and if OK then ill test and fine tune this. I haven't done anything for the scheduler yet as I dont see why any of it is required now.

Some of the copied code can be eliminated if we follow a simpler style (without inheritance and stuff) but anyway I guess you might have had some good reason to do those that way so I kept it as it is. Please take a look

cc @jdubois 